### PR TITLE
fix: `NodeInput` re-renders unexpectedly after `onChange` callback

### DIFF
--- a/src/components/node-graph/components/step/metadata/input-metadata-row.tsx
+++ b/src/components/node-graph/components/step/metadata/input-metadata-row.tsx
@@ -34,7 +34,7 @@ const InputMetadataRow: React.FC<OwnProps> = ({
   isEditable,
 }) => {
   return (
-    <TableRow key={socket.id}>
+    <TableRow>
       <TableCell>
         {isEditable && (
           <Button
@@ -96,13 +96,7 @@ const InputMetadataRow: React.FC<OwnProps> = ({
         )}
       </TableCell>
       <TableCell>
-        <NodeSlot
-          key={socket.id}
-          id={socket.id}
-          label=""
-          type="source"
-          hideLabel
-        />
+        <NodeSlot id={socket.id} label="" type="source" hideLabel />
       </TableCell>
     </TableRow>
   );

--- a/src/components/node-graph/components/step/metadata/input-metadata.tsx
+++ b/src/components/node-graph/components/step/metadata/input-metadata.tsx
@@ -111,9 +111,9 @@ const InputMetadata: React.FC<OwnProps> = ({ step }) => {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {step.outputs.map((socket) => (
+            {step.outputs.map((socket, index) => (
               <InputMetadataRow
-                key={socket.id}
+                key={index}
                 socket={socket}
                 onDelete={deleteSocket(socket.id)}
                 onEditSocketId={handleEditSocketId(socket.id)}

--- a/src/components/node-graph/components/step/metadata/output-metadata-row.tsx
+++ b/src/components/node-graph/components/step/metadata/output-metadata-row.tsx
@@ -31,15 +31,9 @@ const OutputMetadataRow: React.FC<OwnProps> = ({
   isEditable,
 }) => {
   return (
-    <TableRow key={socket.id}>
+    <TableRow>
       <TableCell>
-        <NodeSlot
-          key={socket.id}
-          id={socket.id}
-          label=""
-          type="target"
-          hideLabel
-        />
+        <NodeSlot id={socket.id} label="" type="target" hideLabel />
       </TableCell>
       <TableCell>
         {isEditable ? (

--- a/src/components/node-graph/components/step/metadata/output-metadata.tsx
+++ b/src/components/node-graph/components/step/metadata/output-metadata.tsx
@@ -88,7 +88,7 @@ const OutputMetadata: React.FC<OwnProps> = ({ step }) => {
           <TableBody>
             {step.inputs.map((socket, index) => (
               <OutputMetadataRow
-                key={socket.id}
+                key={index}
                 socket={socket}
                 onUpdateSocketMetadata={updateSocketMetadata(index)}
                 onEditSocketId={handleEditSocketId}

--- a/src/components/node-graph/components/step/node-input.tsx
+++ b/src/components/node-graph/components/step/node-input.tsx
@@ -1,5 +1,5 @@
 import { ClassValue } from "clsx";
-import { useState } from "react";
+import { useEffect, useRef } from "react";
 import { useDebouncedCallback } from "use-debounce";
 
 import { cn } from "@/lib/utils";
@@ -12,21 +12,27 @@ type OwnProps = {
 
 const NodeInput: React.FC<OwnProps> = ({ className = [], value, onChange }) => {
   const debouncedHandleChange = useDebouncedCallback(onChange, 1000);
-  const [displayValue, setDisplayValue] = useState(value);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.value = value;
+    }
+    inputRef.current?.focus();
+  }, [value]);
+
   return (
     <input
+      ref={inputRef}
       type="text"
       className={cn(
         "inline max-w-fit rounded-sm border border-gray-500/50 bg-transparent px-1 text-xs",
         ...className,
       )}
-      value={displayValue}
       onChange={(e) => {
         const newValue = e.target.value;
         debouncedHandleChange(newValue);
-        setDisplayValue(newValue);
       }}
-      size={displayValue.length}
     />
   );
 };

--- a/src/components/node-graph/components/step/node-input.tsx
+++ b/src/components/node-graph/components/step/node-input.tsx
@@ -1,5 +1,5 @@
 import { ClassValue } from "clsx";
-import { useEffect, useRef } from "react";
+import { useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
 
 import { cn } from "@/lib/utils";
@@ -12,27 +12,22 @@ type OwnProps = {
 
 const NodeInput: React.FC<OwnProps> = ({ className = [], value, onChange }) => {
   const debouncedHandleChange = useDebouncedCallback(onChange, 1000);
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (inputRef.current) {
-      inputRef.current.value = value;
-    }
-    inputRef.current?.focus();
-  }, [value]);
+  const [displayValue, setDisplayValue] = useState(value);
 
   return (
     <input
-      ref={inputRef}
       type="text"
       className={cn(
         "inline max-w-fit rounded-sm border border-gray-500/50 bg-transparent px-1 text-xs",
         ...className,
       )}
+      value={displayValue}
       onChange={(e) => {
         const newValue = e.target.value;
+        setDisplayValue(newValue);
         debouncedHandleChange(newValue);
       }}
+      size={displayValue.length}
     />
   );
 };

--- a/src/components/node-graph/components/step/step-node.tsx
+++ b/src/components/node-graph/components/step/step-node.tsx
@@ -93,9 +93,9 @@ export function StepNode({ data }: { data: Step }) {
         <div className="text-xs font-light">
           <div className="flex flex-row justify-between">
             <NodeSlotGroup>
-              {data.inputs.map((stepSocket: StepSocket) => (
+              {data.inputs.map((stepSocket: StepSocket, index: number) => (
                 <NodeSlot
-                  key={stepSocket.id}
+                  key={index}
                   id={stepSocket.id}
                   label={stepSocket.id}
                   type="target"
@@ -117,9 +117,9 @@ export function StepNode({ data }: { data: Step }) {
               )}
             </NodeSlotGroup>
             <NodeSlotGroup>
-              {data.outputs.map((stepSocket: StepSocket) => (
+              {data.outputs.map((stepSocket: StepSocket, index: number) => (
                 <NodeSlot
-                  key={stepSocket.id}
+                  key={index}
                   id={stepSocket.id}
                   label={stepSocket.id}
                   type="source"

--- a/src/features/problems/components/tasks/graph-view.tsx
+++ b/src/features/problems/components/tasks/graph-view.tsx
@@ -119,7 +119,7 @@ const GraphView: React.FC = () => {
         },
       });
     },
-    [dispatch, edges, isEditing],
+    [dispatch, isEditing],
   );
 
   const edgeReconnectSuccessful = useRef(true);
@@ -148,7 +148,7 @@ const GraphView: React.FC = () => {
       });
       edgeReconnectSuccessful.current = true;
     },
-    [dispatch, edges, isEditing],
+    [dispatch, isEditing],
   );
 
   const onReconnectEnd = useCallback(

--- a/src/features/tasks/forms/programming-form.tsx
+++ b/src/features/tasks/forms/programming-form.tsx
@@ -215,11 +215,8 @@ const ProgrammingForm: React.FC<OwnProps> = ({ initialValue, onSubmit }) => {
                 Add input
               </Button>
               {form.getValues("required_inputs").map((input, index) => (
-                <Collapsible className="w-full" key={input.id}>
-                  <div
-                    className="flex gap-4 rounded-md border p-2"
-                    key={input.id}
-                  >
+                <Collapsible className="w-full" key={index}>
+                  <div className="flex gap-4 rounded-md border p-2" key={index}>
                     <NodeInput
                       className={["min-w-[160px]", "font-mono"]}
                       value={input.id}


### PR DESCRIPTION
the input actually gets deselected after every edit because it rerenders
this scuffed partial fix makes it a bit less bad by refocusing the edited input, but still resets the cursor position to the end