### PR TITLE
feat: resizable code/graph editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",
     "react-icons": "^5.4.0",
+    "react-resizable-panels": "^2.1.7",
     "react-router-dom": "^6.29.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       react-icons:
         specifier: ^5.4.0
         version: 5.4.0(react@18.3.1)
+      react-resizable-panels:
+        specifier: ^2.1.7
+        version: 2.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom:
         specifier: ^6.29.0
         version: 6.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2279,6 +2282,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-resizable-panels@2.1.7:
+    resolution: {integrity: sha512-JtT6gI+nURzhMYQYsx8DKkx6bSoOGFp7A3CwMrOb8y5jFHFyqwo9m68UhmXRw57fRVJksFn1TSlm3ywEQ9vMgA==}
+    peerDependencies:
+      react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   react-router-dom@6.29.0:
     resolution: {integrity: sha512-pkEbJPATRJ2iotK+wUwHfy0xs2T59YPEN8BQxVCPeBZvK7kfPESRc/nyxzdcxR17hXgUPYx2whMwl+eo9cUdnQ==}
@@ -4619,6 +4628,11 @@ snapshots:
       use-sidecar: 1.1.3(@types/react@18.3.18)(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.18
+
+  react-resizable-panels@2.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react-router-dom@6.29.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:

--- a/src/components/node-graph/components/step/node-input.tsx
+++ b/src/components/node-graph/components/step/node-input.tsx
@@ -18,7 +18,7 @@ const NodeInput: React.FC<OwnProps> = ({ className = [], value, onChange }) => {
     <input
       type="text"
       className={cn(
-        "inline max-w-fit rounded-sm border border-gray-500/50 bg-transparent p-1 font-mono text-xs",
+        "nodrag inline max-w-fit rounded-sm border border-gray-500/50 bg-transparent p-1 font-mono text-xs",
         ...className,
       )}
       value={displayValue}

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -1,0 +1,43 @@
+import { DragHandleDots2Icon } from "@radix-ui/react-icons";
+import * as ResizablePrimitive from "react-resizable-panels";
+
+import { cn } from "@/lib/utils";
+
+const ResizablePanelGroup = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) => (
+  <ResizablePrimitive.PanelGroup
+    className={cn(
+      "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
+      className,
+    )}
+    {...props}
+  />
+);
+
+const ResizablePanel = ResizablePrimitive.Panel;
+
+const ResizableHandle = ({
+  withHandle,
+  className,
+  ...props
+}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+  withHandle?: boolean;
+}) => (
+  <ResizablePrimitive.PanelResizeHandle
+    className={cn(
+      "relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90",
+      className,
+    )}
+    {...props}
+  >
+    {withHandle && (
+      <div className="z-10 flex h-4 w-3 items-center justify-center rounded-sm border bg-border">
+        <DragHandleDots2Icon className="h-2.5 w-2.5" />
+      </div>
+    )}
+  </ResizablePrimitive.PanelResizeHandle>
+);
+
+export { ResizableHandle, ResizablePanel, ResizablePanelGroup };

--- a/src/features/problems/components/tasks/graph-editor.tsx
+++ b/src/features/problems/components/tasks/graph-editor.tsx
@@ -104,13 +104,13 @@ const GraphEditor: React.FC<GraphEditorProps> = ({ graphId, className }) => {
   }, [layoutApplied, rfInstance]);
 
   useEffect(() => {
-    setFlowNodes(
+    setFlowNodes((flowNodes) =>
       nodeData.map((node) => {
         const existingRfNode = flowNodes.find((n) => n.id === node.id);
         return existingRfNode ? { ...existingRfNode, data: node.data } : node;
       }),
     );
-  }, [nodeData, flowNodes, setFlowNodes]);
+  }, [nodeData, setFlowNodes]);
 
   useEffect(() => setFlowEdges(edgeData), [edgeData, setFlowEdges]);
 

--- a/src/features/problems/components/tasks/graph-editor.tsx
+++ b/src/features/problems/components/tasks/graph-editor.tsx
@@ -28,6 +28,11 @@ import {
 import { GraphEdge } from "@/api";
 import { StepNode } from "@/components/node-graph/components/step/step-node";
 import { Button } from "@/components/ui/button";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
 import { cn } from "@/lib/utils";
 import getLayoutedElements from "@/utils/graph";
 
@@ -181,55 +186,60 @@ const GraphEditor: React.FC<GraphEditorProps> = ({ graphId, className }) => {
 
   return (
     <div
-      className={cn("grid gap-1", className, {
-        "grid-cols-5": selectedSocketId,
+      className={cn(className, {
         "fixed inset-0 z-30 h-full bg-black/100 animate-in fade-in": expanded,
       })}
       data-state={expanded ? "open" : "closed"}
     >
-      {selectedSocketId && (
-        <div className="col-span-2">
-          <GraphFileEditor />
-        </div>
-      )}
-      <div className={selectedSocketId ? "col-span-3" : ""}>
-        <ReactFlow
-          id={graphId}
-          onInit={onInit}
-          nodeTypes={nodeTypes}
-          nodes={flowNodes}
-          edges={flowEdges}
-          onNodesChange={onFlowNodesChange}
-          onEdgesChange={onFlowEdgesChange}
-          onConnect={onConnect}
-          onReconnectStart={onReconnectStart}
-          onReconnectEnd={onReconnectEnd}
-          onReconnect={onReconnect}
-          nodesConnectable={edit}
-          colorMode="dark"
-          proOptions={{ hideAttribution: true }}
-        >
-          {/* Custom controls */}
-          <div
-            className={cn(
-              "absolute right-1 top-1 z-10 mt-4 flex space-x-1 px-2",
-              { "z-30": expanded },
-            )}
+      <ResizablePanelGroup direction="horizontal">
+        {selectedSocketId && (
+          <>
+            <ResizablePanel defaultSize={2} order={0}>
+              <GraphFileEditor />
+            </ResizablePanel>
+            <ResizableHandle withHandle />
+          </>
+        )}
+
+        <ResizablePanel defaultSize={3} order={1}>
+          <ReactFlow
+            id={graphId}
+            onInit={onInit}
+            nodeTypes={nodeTypes}
+            nodes={flowNodes}
+            edges={flowEdges}
+            onNodesChange={onFlowNodesChange}
+            onEdgesChange={onFlowEdgesChange}
+            onConnect={onConnect}
+            onReconnectStart={onReconnectStart}
+            onReconnectEnd={onReconnectEnd}
+            onReconnect={onReconnect}
+            nodesConnectable={edit}
+            colorMode="dark"
+            proOptions={{ hideAttribution: true }}
           >
-            {edit && <AddNodeButton />}
-            <Button
-              onClick={() => setExpanded((prev) => !prev)}
-              type="button"
-              variant="outline"
+            {/* Custom controls */}
+            <div
+              className={cn(
+                "absolute right-1 top-1 z-10 mt-4 flex space-x-1 px-2",
+                { "z-30": expanded },
+              )}
             >
-              {expanded ? <ShrinkIcon /> : <ExpandIcon />}
-            </Button>
-          </div>
-          <Background variant={BackgroundVariant.Dots} />
-          <Controls showInteractive={edit} />
-          <MiniMap />
-        </ReactFlow>
-      </div>
+              {edit && <AddNodeButton />}
+              <Button
+                onClick={() => setExpanded((prev) => !prev)}
+                type="button"
+                variant="outline"
+              >
+                {expanded ? <ShrinkIcon /> : <ExpandIcon />}
+              </Button>
+            </div>
+            <Background variant={BackgroundVariant.Dots} />
+            <Controls showInteractive={edit} />
+            <MiniMap />
+          </ReactFlow>
+        </ResizablePanel>
+      </ResizablePanelGroup>
     </div>
   );
 };


### PR DESCRIPTION
this pr has minor ux fixes (no logic changes)

- use <Resizable> for code editor display (solves #22)
- make node inputs selectable (add nodrag class)
- fix minor infinite rendering bug